### PR TITLE
Ensure we all use the same event loop without changes needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
             "Revolt\\EventLoop\\Adapter\\React\\": "src"
         },
         "files": [
+            "src/bootstrap.php",
             "etc/Factory.php"
         ]
     },

--- a/examples/1-timers.php
+++ b/examples/1-timers.php
@@ -3,18 +3,18 @@
 // This example is adapted from reactphp/event-loop, but running on Revolt's event loop.
 // https://github.com/reactphp/event-loop/blob/85a0b7c0e35a47387a61d2ba8a772a7855b6af86/examples/01-timers.php
 
-use Revolt\EventLoop\Adapter\React\RevoltLoop;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = RevoltLoop::get();
+echo 'Running with the following event loop: ', \get_class(Loop::get()), PHP_EOL;
 
-$loop->addTimer(0.8, function () {
+Loop::addTimer(0.8, function () {
     echo 'world!' . PHP_EOL;
 });
 
-$loop->addTimer(0.3, function () {
+Loop::addTimer(0.3, function () {
     echo 'hello ';
 });
 
-$loop->run();
+Loop::run();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use React\EventLoop\Loop;
+use Revolt\EventLoop\Adapter\React\RevoltLoop;
+
+/**
+ * @psalm-suppress InternalMethod
+ */
+Loop::set(RevoltLoop::get());


### PR DESCRIPTION
This change sets the event loop on `React\EventLoop\Loop` to `Revolt\EventLoop\Adapter\React\RevoltLoop` so that there are no changes needed anywhere to use a single event loop.